### PR TITLE
Replace moment date formatting with local version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Usage:
   argo()
     .use(clf)
     .target("SOME URL")
-    .list(3000)
+    .listen(3000)
 ```

--- a/format_date.js
+++ b/format_date.js
@@ -1,0 +1,35 @@
+var MONTH_NAMES = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+];
+
+// Pad a value with the `0` character until it's length is equal to
+// `len` or if no length is given pad to len=2.
+function pad(val, len) {
+  val = String(val);
+  len = len || 2;
+  while (val.length < len) {
+    val = '0' + val;
+  }
+  return val;
+}
+
+// Formats dates to a common log formats time in strftime format 
+// `%d/%b/%Y:%H:%M:%S %z.` Eg. 8/Dec/2018:14:47:51 -0500
+// See: https://en.wikipedia.org/wiki/Common_Log_Format
+function formatDate(date) {
+  var offset = date.getTimezoneOffset();
+  var tzOffset = (offset > 0 ? '-' : '+') 
+                + pad(Math.floor(Math.abs(offset) / 60) 
+                       * 100 + Math.abs(offset) % 60, 4);
+  
+  return date.getDate() + '/' 
+         + MONTH_NAMES[date.getMonth()]
+         + '/' + date.getFullYear()
+         + ':' + pad(date.getHours())
+         + ':' + pad(date.getMinutes())
+         + ':' + pad(date.getSeconds())
+         + ' ' + tzOffset;
+}
+
+module.exports = formatDate;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var Stream = require('stream');
-var moment = require('moment');
+var formatDate = require('./format_date');
 
 module.exports = function(handle) {
   handle('response', { affinity: 'sink' }, function(env, next) {
@@ -8,7 +8,7 @@ module.exports = function(handle) {
       var res = env.response || env.target.response;
       var UNKNOWN = '-';
       var ip = req.connection.remoteAddress;
-      var date = '[' + moment(Date.now()).format('D/MMM/YYYY:HH:mm:ss ZZ') + ']';
+      var date = '[' + formatDate(new Date()) + ']';
       var method = req.method;
       var url = req.url;
       var requestSummary = '"' + method + ' ' + url + '"';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Argo logging using CLF",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/mocha test/"
   },
   "repository": {
     "type": "git",
@@ -24,6 +24,9 @@
     "url": "https://github.com/mdobson/argo-clf/issues"
   },
   "dependencies": {
-    "moment": "~2.3.1"
+  },
+  "devDependencies": {
+    "mocha": "^5.2.0",
+    "moment": "^2.3.1"
   }
 }

--- a/test/format_date_test.js
+++ b/test/format_date_test.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const formatDate = require('../format_date');
+const moment = require('moment');
+
+describe('Test formatDate', () => {
+
+  // Takes a `date` and asserts that moments and formatDate are equal.
+  function assertDateEquals(date) {
+    let dateString = moment(date).format('D/MMM/YYYY:HH:mm:ss ZZ');
+    let dateStringNew = formatDate(date)
+    assert.equal(dateString, dateStringNew);
+  }
+
+  it('moment and formatDate should be equal for known date', () => {        
+    assertDateEquals(new Date('January 12, 1989 12:32:17 EST'));
+  });
+
+  it('moment and formatDate should be equal for known date 0 date', () => {        
+    assertDateEquals(new Date(0));
+  });
+
+  it('moment and formatDate should be equal for 100K random dates', () => {
+    let interactions = 100000;
+    for (let i=0; i<interactions; i++) {
+      assertDateEquals(new Date(Math.random()* new Date().getTime()));
+    }
+  });
+});


### PR DESCRIPTION
Removes `moment` dependency to avoid the large include with argo and zetta. See #4 Also fixes a security vulnerability included in moment. https://nodesecurity.io/advisories/532
